### PR TITLE
Added option to select frames to download

### DIFF
--- a/imaging_db/cli/data_downloader.py
+++ b/imaging_db/cli/data_downloader.py
@@ -10,6 +10,7 @@ import imaging_db.metadata.json_validator as json_validator
 
 from tqdm import tqdm
 
+
 def parse_args():
     """
     Parse command line arguments for CLI
@@ -23,25 +24,25 @@ def parse_args():
         help="Unique dataset identifier",
     )
     parser.add_argument(
-        '--p',
+        '-p', '--positions',
         type=int,
         nargs='+',
         help="Tuple containing position indices to download",
     )
     parser.add_argument(
-        '--t',
+        '-t', '--times',
         type=int,
         nargs='+',
         help="Tuple containing time indices to download",
     )
     parser.add_argument(
-        '--c',
+        '-c', '--channels',
         type=str,
         nargs='+',
         help="Tuple containing the channels to download",
     )
     parser.add_argument(
-        '--z',
+        '--z', '--slices',
         type=int,
         nargs='+',
         help="Tuple containing the z slices to download",
@@ -112,7 +113,6 @@ def download_data(args):
     # dataset_serial. It stops if the subdirectory already exists to avoid
     # the risk of overwriting existing data
 
-
     dest_folder = os.path.join(args.dest, dataset_serial)
     try:
         os.makedirs(dest_folder, exist_ok=False)
@@ -139,30 +139,27 @@ def download_data(args):
         # Get all the slicing args and recast as tuples
         if args.p is None:
             pos = 'all'
-        
         else:
             pos = tuple(args.p)
 
         if args.t is None:
             times = 'all'
-        
         else:
             times = tuple(args.t)
 
         if args.c is None:
             channels = 'all'
-        
         else:
             channels = tuple(args.c)
 
         if args.z is None:
             slices = 'all'
-        
         else:
             slices = tuple(args.z)
 
         # Get the metadata from the requested frames
-        global_meta, frames_meta = db_inst.get_frames_meta(pos=pos, times=times, channels=channels, slices=slices)
+        global_meta, frames_meta = db_inst.get_frames_meta(
+            pos=pos, times=times, channels=channels, slices=slices)
 
         # Write global metadata to dest folder
         global_meta_filename = os.path.join(

--- a/imaging_db/cli/data_downloader.py
+++ b/imaging_db/cli/data_downloader.py
@@ -42,7 +42,7 @@ def parse_args():
         help="Tuple containing the channels to download",
     )
     parser.add_argument(
-        '--z', '--slices',
+        '-z', '--slices',
         type=int,
         nargs='+',
         help="Tuple containing the z slices to download",
@@ -137,25 +137,25 @@ def download_data(args):
         s3_dir, file_names = db_inst.get_filenames()
     else:
         # Get all the slicing args and recast as tuples
-        if args.p is None:
+        if args.positions is None:
             pos = 'all'
         else:
-            pos = tuple(args.p)
+            pos = tuple(args.positions)
 
-        if args.t is None:
+        if args.times is None:
             times = 'all'
         else:
-            times = tuple(args.t)
+            times = tuple(args.times)
 
-        if args.c is None:
+        if args.channels is None:
             channels = 'all'
         else:
-            channels = tuple(args.c)
+            channels = tuple(args.channels)
 
-        if args.z is None:
+        if args.slices is None:
             slices = 'all'
         else:
-            slices = tuple(args.z)
+            slices = tuple(args.slices)
 
         # Get the metadata from the requested frames
         global_meta, frames_meta = db_inst.get_frames_meta(

--- a/imaging_db/cli/data_downloader.py
+++ b/imaging_db/cli/data_downloader.py
@@ -23,6 +23,30 @@ def parse_args():
         help="Unique dataset identifier",
     )
     parser.add_argument(
+        '--p',
+        type=int,
+        nargs='+',
+        help="Tuple containing position indices to download",
+    )
+    parser.add_argument(
+        '--t',
+        type=int,
+        nargs='+',
+        help="Tuple containing time indices to download",
+    )
+    parser.add_argument(
+        '--c',
+        type=str,
+        nargs='+',
+        help="Tuple containing the channels to download",
+    )
+    parser.add_argument(
+        '--z',
+        type=int,
+        nargs='+',
+        help="Tuple containing the z slices to download",
+    )
+    parser.add_argument(
         '--dest',
         type=str,
         help="Main destination folder, in which a subfolder named args.id "
@@ -112,8 +136,34 @@ def download_data(args):
             "You set metadata *and* download to False. You get nothing."
         s3_dir, file_names = db_inst.get_filenames()
     else:
-        # Dataset should be split into frames, get metadata
-        global_meta, frames_meta = db_inst.get_frames_meta()
+        # Get all the slicing args and recast as tuples
+        if args.p is None:
+            pos = 'all'
+        
+        else:
+            pos = tuple(args.p)
+
+        if args.t is None:
+            times = 'all'
+        
+        else:
+            times = tuple(args.t)
+
+        if args.c is None:
+            channels = 'all'
+        
+        else:
+            channels = tuple(args.c)
+
+        if args.z is None:
+            slices = 'all'
+        
+        else:
+            slices = tuple(args.z)
+
+        # Get the metadata from the requested frames
+        global_meta, frames_meta = db_inst.get_frames_meta(pos=pos, times=times, channels=channels, slices=slices)
+
         # Write global metadata to dest folder
         global_meta_filename = os.path.join(
             dest_folder,

--- a/imaging_db/database/db_session.py
+++ b/imaging_db/database/db_session.py
@@ -317,42 +317,35 @@ class DatabaseOperations:
         # Filter by channel
         if channels == 'all':
             pass
-
         elif type(channels) is tuple:
             sliced_frames = sliced_frames.filter(Frames.channel_name.in_(channels))
 
         else:
-            print('Invalid channel query')
+            raise ValueError('Invalid channel query')
 
         # Filter by slice
         if slices == 'all':
             pass
-
         elif type(slices) is tuple:
             sliced_frames = sliced_frames.filter(Frames.slice_idx.in_(slices))
-
         else:
-            print('Invalid slice query')
+            raise ValueError('Invalid slice query')
 
         # Filter by time
         if times == 'all':
             pass
-
         elif type(slices) is tuple:
             sliced_frames = sliced_frames.filter(Frames.time_idx.in_(timess))
-
         else:
-            print('Invalid slice query')
+            raise ValueError('Invalid slice query')
 
-        # Filter by sosition
+        # Filter by position
         if pos == 'all':
             pass
-
         elif type(slices) is tuple:
             sliced_frames = sliced_frames.filter(Frames.pos_idx.in_(pos))
-
         else:
-            print('Invalid slice query')
+            raise ValueError('Invalid slice query')
 
         sliced_frames.order_by(Frames.slice_idx).order_by(Frames.channel_idx) \
             .order_by(Frames.time_idx).order_by(Frames.pos_idx)


### PR DESCRIPTION
To address #32, I added an option to choose frames to download through the CLI.
- added a private method (`_slice_frames()`) to `db_session.py` to build a query for specific frames based on specified indices (time, pos, channel, slice).
- updated `get_filenames()` and `get_frames_meta()` in `db_session.py` to support specifying which frames to download
- updated the CLI to support downloading only specified frames.
- ran nose and all 40 tests passed.

Example CLI usage (downloads z slices 0, 1 and channels Cy3 and DAPI from ISP-2018-06-01-00-00-00-0002:
`python data_downloader.py --id ISP-2018-06-01-00-00-00-0002  --dest ./test --z 0 1 --c 'Cy3' 'DAPI'  --login credentials.json`


