### PR TITLE
Queries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - 3.6
 sudo: true
+dist: trusty
 services:
   - postgresql
 addons:

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -1,0 +1,35 @@
+name: imaging
+channels:
+  - anaconda
+  - conda-forge
+  - defaults
+dependencies:
+  - alembic
+  - awscli
+  - boto3
+  - Cython
+  - ffmpeg
+  - jsonschema
+  - jupyter
+  - matplotlib
+  - moto
+  - natsort
+  - nose
+  - numpy
+  - opencv
+  - pandas
+  - psycopg2
+  - pydot
+  - PyYAML
+  - x264
+  - testfixtures
+  - scikit-image
+  - scikit-learn
+  - scipy
+  - sqlalchemy
+  - tqdm
+  - zarr
+  - ipython
+  - pip
+  - pip:
+    - tifffile

--- a/imaging_db/cli/data_downloader.py
+++ b/imaging_db/cli/data_downloader.py
@@ -26,24 +26,28 @@ def parse_args():
     parser.add_argument(
         '-p', '--positions',
         type=int,
+        default=None,
         nargs='+',
         help="Tuple containing position indices to download",
     )
     parser.add_argument(
         '-t', '--times',
         type=int,
+        default=None,
         nargs='+',
         help="Tuple containing time indices to download",
     )
     parser.add_argument(
         '-c', '--channels',
         type=str,
+        default=None,
         nargs='+',
         help="Tuple containing the channel names or indices to download",
     )
     parser.add_argument(
         '-z', '--slices',
         type=int,
+        default=None,
         nargs='+',
         help="Tuple containing the z slices to download",
     )
@@ -160,19 +164,11 @@ def download_data(dataset_serial,
             )
     else:
         # Get all the slicing args and recast as tuples
-        if positions is None:
-            pos = 'all'
-        else:
-            pos = tuple(positions)
-
-        if times is None:
-            times = 'all'
-        else:
+        if positions is not None:
+            positions = tuple(positions)
+        if times is not None:
             times = tuple(times)
-
-        if channels is None:
-            channels = 'all'
-        else:
+        if channels is not None:
             # If channels can be converted to ints, they're indices
             try:
                 channels = [int(c) for c in channels]
@@ -180,17 +176,14 @@ def download_data(dataset_serial,
                 # Channels are names, not indices
                 channels = channels
             channels = tuple(channels)
-
-        if slices is None:
-            slices = 'all'
-        else:
+        if slices is not None:
             slices = tuple(slices)
 
         # Get the metadata from the requested frames
         with db_ops.session_scope(db_connection) as session:
             global_meta, frames_meta = db_inst.get_frames_meta(
                 session=session,
-                pos=pos,
+                positions=positions,
                 times=times,
                 channels=channels,
                 slices=slices,

--- a/imaging_db/cli/data_downloader.py
+++ b/imaging_db/cli/data_downloader.py
@@ -20,6 +20,7 @@ def parse_args():
     parser.add_argument(
         '--id',
         type=str,
+        required=True,
         help="Unique dataset identifier",
     )
     parser.add_argument(
@@ -49,9 +50,9 @@ def parse_args():
     parser.add_argument(
         '--dest',
         type=str,
+        required=True,
         help="Main destination directory, in which a subdir named args.id "
              "\will be created",
-        required=True
     )
     parser.add_argument(
         '--metadata',
@@ -80,6 +81,7 @@ def parse_args():
     parser.add_argument(
         '--login',
         type=str,
+        required=True,
         help="Full path to file containing JSON with DB login credentials",
     )
     parser.add_argument(
@@ -92,7 +94,7 @@ def parse_args():
     return parser.parse_args()
 
 
-def download_data(id,
+def download_data(dataset_serial,
                   login,
                   dest,
                   metadata=True,
@@ -106,7 +108,7 @@ def download_data(id,
     Find all files associated with unique project identifier and
     download them to a local directory.
 
-    :param str id: Unique dataset identifier
+    :param str dataset_serial: Unique dataset identifier
     :param str login: Full path to json file containing database login
             credentials
     :param str dest: Local destination directory name
@@ -124,7 +126,6 @@ def download_data(id,
             names (default None downloads all)
     :param list, None slices: Slice (z) integer indices (Default None downloads all)
     """
-    dataset_serial = id
     try:
         cli_utils.validate_id(dataset_serial)
     except AssertionError as e:
@@ -142,15 +143,12 @@ def download_data(id,
 
     # Get database connection URI
     db_connection = db_utils.get_connection_str(login)
+    db_utils.check_connection(db_connection)
+
     # Instantiate database class
-    try:
-        db_inst = db_ops.DatabaseOperations(
-            dataset_serial=dataset_serial,
-        )
-        with db_ops.session_scope(db_connection) as session:
-            db_ops.test_connection(session)
-    except Exception as e:
-        raise IOError("Can't instantiate DB: {}".format(e))
+    db_inst = db_ops.DatabaseOperations(
+        dataset_serial=dataset_serial,
+    )
 
     if metadata is False:
         # Just download file(s)
@@ -230,7 +228,7 @@ def download_data(id,
 if __name__ == '__main__':
     args = parse_args()
     download_data(
-        id=args.id,
+        dataset_serial=args.id,
         login=args.login,
         dest=args.dest,
         metadata=args.metadata,

--- a/imaging_db/cli/data_downloader.py
+++ b/imaging_db/cli/data_downloader.py
@@ -92,32 +92,48 @@ def parse_args():
     return parser.parse_args()
 
 
-def download_data(args):
+def download_data(id,
+                  login,
+                  dest,
+                  metadata=True,
+                  download=True,
+                  nbr_workers=None,
+                  positions=None,
+                  times=None,
+                  channels=None,
+                  slices=None):
     """
     Find all files associated with unique project identifier and
-    download them to local folder
+    download them to a local directory.
 
-    :param args: Command line arguments:
-        str id: Unique dataset identifier
-        str dest: Local destination directory name
-        bool metadata: Writes metadata (default True)
-            global metadata in json, local for each frame in csv
-        bool download: Downloads all files associated with dataset (default)
+    :param str id: Unique dataset identifier
+    :param str login: Full path to json file containing database login
+            credentials
+    :param str dest: Local destination directory name
+    :param bool download: Downloads all files associated with dataset (default)
             If False, will only write csvs with metadata. Only for
             datasets split into frames
-        str login: Full path to json file containing database login
-            credentials
+    :param bool metadata: Writes metadata (default True)
+            global metadata in json, local for each frame in csv
+    :param int, None nbr_workers: Number of workers for parallel download
+            If None, it defaults to number of machine processors * 5
+    :param list, None positions: Positions (FOVs) as integers (default
+            None downloads all)
+    :param list, None times: Timepoints as integers (default None downloads all)
+    :param list, None channels: Channels as integer indices or strings for channel
+            names (default None downloads all)
+    :param list, None slices: Slice (z) integer indices (Default None downloads all)
     """
-    dataset_serial = args.id
+    dataset_serial = id
     try:
         cli_utils.validate_id(dataset_serial)
     except AssertionError as e:
         raise AssertionError("Invalid ID:", e)
 
-    # Create output directory as a subdirectory in args.dest named
+    # Create output directory as a subdirectory in dest named
     # dataset_serial. It stops if the subdirectory already exists to avoid
     # the risk of overwriting existing data
-    dest_dir = os.path.join(args.dest, dataset_serial)
+    dest_dir = os.path.join(dest, dataset_serial)
     try:
         os.makedirs(dest_dir, exist_ok=False)
     except FileExistsError as e:
@@ -125,7 +141,7 @@ def download_data(args):
             "Folder {} already exists, {}".format(dest_dir, e))
 
     # Get database connection URI
-    db_connection = db_utils.get_connection_str(args.login)
+    db_connection = db_utils.get_connection_str(login)
     # Instantiate database class
     try:
         db_inst = db_ops.DatabaseOperations(
@@ -136,9 +152,9 @@ def download_data(args):
     except Exception as e:
         raise IOError("Can't instantiate DB: {}".format(e))
 
-    if args.metadata is False:
+    if metadata is False:
         # Just download file(s)
-        assert args.download,\
+        assert download,\
             "You set metadata *and* download to False. You get nothing."
         with db_ops.session_scope(db_connection) as session:
             s3_dir, file_names = db_inst.get_filenames(
@@ -146,31 +162,31 @@ def download_data(args):
             )
     else:
         # Get all the slicing args and recast as tuples
-        if args.positions is None:
+        if positions is None:
             pos = 'all'
         else:
-            pos = tuple(args.positions)
+            pos = tuple(positions)
 
-        if args.times is None:
+        if times is None:
             times = 'all'
         else:
-            times = tuple(args.times)
+            times = tuple(times)
 
-        if args.channels is None:
+        if channels is None:
             channels = 'all'
         else:
             # If channels can be converted to ints, they're indices
             try:
-                channels = [int(c) for c in args.channels]
+                channels = [int(c) for c in channels]
             except ValueError:
                 # Channels are names, not indices
-                channels = args.channels
+                channels = channels
             channels = tuple(channels)
 
-        if args.slices is None:
+        if slices is None:
             slices = 'all'
         else:
-            slices = tuple(args.slices)
+            slices = tuple(slices)
 
         # Get the metadata from the requested frames
         with db_ops.session_scope(db_connection) as session:
@@ -200,18 +216,28 @@ def download_data(args):
         s3_dir = global_meta["s3_dir"]
         file_names = frames_meta["file_name"]
 
-    if args.download:
-        if args.nbr_workers is not None:
-            assert args.nbr_workers > 0,\
-                "Nbr of worker must be >0, not {}".format(args.nbr_workers)
+    if download:
+        if nbr_workers is not None:
+            assert nbr_workers > 0,\
+                "Nbr of worker must be >0, not {}".format(nbr_workers)
         data_loader = s3_storage.DataStorage(
             s3_dir=s3_dir,
-            nbr_workers=args.nbr_workers,
+            nbr_workers=nbr_workers,
         )
         data_loader.download_files(file_names, dest_dir)
 
 
 if __name__ == '__main__':
     args = parse_args()
-    download_data(args)
-
+    download_data(
+        id=args.id,
+        login=args.login,
+        dest=args.dest,
+        metadata=args.metadata,
+        download=args.download,
+        nbr_workers=args.nbr_workers,
+        positions=args.positions,
+        times=args.times,
+        channels=args.channels,
+        slices=args.slices,
+    )

--- a/imaging_db/cli/data_uploader.py
+++ b/imaging_db/cli/data_uploader.py
@@ -3,7 +3,6 @@
 import argparse
 import os
 import pandas as pd
-import time
 
 import imaging_db.utils.cli_utils as cli_utils
 import imaging_db.database.db_operations as db_ops
@@ -28,16 +27,19 @@ def parse_args():
     parser.add_argument(
         '--csv',
         type=str,
+        required=True,
         help="Full path to csv file",
     )
     parser.add_argument(
         '--login',
         type=str,
+        required=True,
         help="Full path to file containing JSON with DB login credentials",
     )
     parser.add_argument(
         '--config',
         type=str,
+        required=True,
         help="Full path to file containing JSON with upload configurations",
     )
     parser.add_argument(
@@ -95,9 +97,7 @@ def upload_data_and_update_db(csv,
 
     # Get database connection URI
     db_connection = db_utils.get_connection_str(login)
-    # Make sure we can connect to the database
-    with db_ops.session_scope(db_connection) as session:
-        db_ops.test_connection(session)
+    db_utils.check_connection(db_connection)
     # Read and validate config json
     config_json = json_ops.read_json_file(
         json_filename=config,

--- a/imaging_db/cli/data_uploader.py
+++ b/imaging_db/cli/data_uploader.py
@@ -57,15 +57,18 @@ def parse_args():
     return parser.parse_args()
 
 
-def upload_data_and_update_db(args):
+def upload_data_and_update_db(csv,
+                              login,
+                              config,
+                              nbr_workers=None,
+                              override=False):
     """
     Split, crop volumes and flatfield correct images in input and target
     directories. Writes output as npy files for faster reading while training.
     TODO: Add logging instead of printing
 
-    :param list args:    parsed args containing
-        login: Full path to json file containing login credentials
-        csv: Full path to csv file containing the following fields
+    :param str login: Full path to json file containing login credentials
+    :param str csv: Full path to csv file containing the following fields
         for each file to be uploaded:
             str dataset_id: Unique dataset ID <ID>-YYYY-MM-DD-HH-MM-SS-<SSSS>
             str file_name: Full path to file to be uploaded
@@ -74,26 +77,30 @@ def upload_data_and_update_db(args):
                 list positions: Which position files in folder to upload.
                 Uploads all if left empty and file_name is a folder.
                 Only valid for ome-tiff uploads.
-        config: Full path co json config file containing the fields:
+    :param str config: Full path co json config file containing the fields:
             str upload_type: Specify if the file should be split prior to upload
                 Valid options: 'frames' or 'file'
             str frames_format: Which file splitter class to use.
                 Valid options: 'ome_tiff', 'tiffolder', 'tifvideo'
             str json_meta: If slice, give full path to json metadata schema
+    :param int, None nbr_workers: Number of workers for parallel uploads
+    :param bool override: Use with caution if your upload if your upload was
+            interrupted and you want to overwrite existing data in database
+            and storage
     """
     # Assert that csv file exists and load it
-    assert os.path.isfile(args.csv), \
-        "File doesn't exist: {}".format(args.csv)
-    files_data = pd.read_csv(args.csv)
+    assert os.path.isfile(csv), \
+        "File doesn't exist: {}".format(csv)
+    files_data = pd.read_csv(csv)
 
     # Get database connection URI
-    db_connection = db_utils.get_connection_str(args.login)
+    db_connection = db_utils.get_connection_str(login)
     # Make sure we can connect to the database
     with db_ops.session_scope(db_connection) as session:
         db_ops.test_connection(session)
     # Read and validate config json
     config_json = json_ops.read_json_file(
-        json_filename=args.config,
+        json_filename=config,
         schema_name="CONFIG_SCHEMA",
     )
     # Assert that upload type is valid
@@ -102,9 +109,9 @@ def upload_data_and_update_db(args):
         "upload_type should be 'file' or 'frames', not {}".format(
             upload_type,
         )
-    if args.nbr_workers is not None:
-        assert args.nbr_workers > 0, \
-            "Nbr of worker must be >0, not {}".format(args.nbr_workers)
+    if nbr_workers is not None:
+        assert nbr_workers > 0, \
+            "Nbr of worker must be >0, not {}".format(nbr_workers)
 
     # Make sure microscope is a string
     microscope = None
@@ -137,7 +144,7 @@ def upload_data_and_update_db(args):
             dataset_serial=dataset_serial,
         )
         # Make sure dataset is not already in database
-        if not args.override:
+        if not override:
             with db_ops.session_scope(db_connection) as session:
                 db_inst.assert_unique_id(session)
         # Check for parent dataset
@@ -155,9 +162,9 @@ def upload_data_and_update_db(args):
             frames_inst = splitter_class(
                 data_path=row.file_name,
                 s3_dir=s3_dir,
-                override=args.override,
+                override=override,
                 file_format=FRAME_FILE_FORMAT,
-                nbr_workers=args.nbr_workers,
+                nbr_workers=nbr_workers,
             )
             # Get kwargs if any
             kwargs = {}
@@ -196,7 +203,7 @@ def upload_data_and_update_db(args):
             data_uploader = s3_storage.DataStorage(
                 s3_dir=s3_dir,
             )
-            if not args.override:
+            if not override:
                 data_uploader.assert_unique_id()
             try:
                 data_uploader.upload_file(file_name=row.file_name)
@@ -227,6 +234,10 @@ def upload_data_and_update_db(args):
 
 if __name__ == '__main__':
     args = parse_args()
-    t0 = time.time()
-    upload_data_and_update_db(args)
-    print("Upload time: {:.2f}".format(time.time() - t0))
+    upload_data_and_update_db(
+        csv=args.csv,
+        login=args.login,
+        config=args.config,
+        nbr_workers=args.nbr_workers,
+        override=args.override,
+    )

--- a/imaging_db/cli/query_data.py
+++ b/imaging_db/cli/query_data.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python
+
+import argparse
+import os
+
+import imaging_db.database.db_operations as db_ops
+import imaging_db.metadata.json_operations as json_ops
+import imaging_db.utils.cli_utils as cli_utils
+import imaging_db.utils.db_utils as db_utils
+
+
+def parse_args():
+    """
+    Parse command line arguments for CLI
+
+    :return: namespace containing the arguments passed.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--login',
+        type=str,
+        required=True,
+        help="Full path to file containing JSON with DB login credentials",
+    )
+    # TODO: This is not user friendly. Change it before PR!
+    parser.add_argument(
+        '--search_str',
+        type=str,
+        default=None,
+        help="Search dict as string",
+    )
+    return parser.parse_args()
+
+
+def query_data(login,
+               search_dict=None,
+               ):
+    """
+    Provide CLI access to wrappers for common queries.
+
+    :param str login: Full path to json file containing database login
+            credentials
+    :param dict search_dict: Key/value pairs for dataset fields that should
+            be queried over
+    """
+    # Get database connection URI
+    db_connection = db_utils.get_connection_str(login)
+
+    with db_ops.session_scope(db_connection) as session:
+        datasets = db_ops.get_datasets(session, search_dict)
+        for d in datasets:
+            print(d.dataset_serial)
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    query_data(
+        login=args.login,
+        search_dict=args.search_str,
+    )

--- a/imaging_db/cli/query_data.py
+++ b/imaging_db/cli/query_data.py
@@ -3,6 +3,7 @@
 import argparse
 
 import imaging_db.database.db_operations as db_ops
+import imaging_db.utils.cli_utils as cli_utils
 import imaging_db.utils.db_utils as db_utils
 
 
@@ -82,6 +83,8 @@ def query_data(login,
         search_dict['microscope'] = microscope
     if start_date is not None:
         search_dict['start_date'] = start_date
+        if end_date is not None:
+            cli_utils.assert_date_order(start_date, end_date)
     if end_date is not None:
         search_dict['end_date'] = end_date
     if description is not None:

--- a/imaging_db/cli/query_data.py
+++ b/imaging_db/cli/query_data.py
@@ -69,8 +69,8 @@ def query_data(login,
     :param str project_id: First part of dataset_serial containing
             project ID (e.g. ML)
     :param str microscope: Microscope column
-    :param str start_date: Find >= dates in date_time column
-    :param str end_date: Find <= dates in date_time column
+    :param str start_date: Format YYYY-MM-DD. Find >= dates in date_time column
+    :param str end_date: Format YYYY-MM-DD. Find <= dates in date_time column
     :param str description: Find substring in description column
     """
     # Get database connection URI

--- a/imaging_db/cli/query_data.py
+++ b/imaging_db/cli/query_data.py
@@ -1,11 +1,8 @@
 #!/usr/bin/python
 
 import argparse
-import os
 
 import imaging_db.database.db_operations as db_ops
-import imaging_db.metadata.json_operations as json_ops
-import imaging_db.utils.cli_utils as cli_utils
 import imaging_db.utils.db_utils as db_utils
 
 
@@ -22,39 +19,88 @@ def parse_args():
         required=True,
         help="Full path to file containing JSON with DB login credentials",
     )
-    # TODO: This is not user friendly. Change it before PR!
     parser.add_argument(
-        '--search_str',
+        '--project_id',
         type=str,
         default=None,
-        help="Search dict as string",
+        help="Project ID substring (first part of dataset ID)",
+    )
+    parser.add_argument(
+        '--microscope',
+        type=str,
+        default=None,
+        help="Substring of microscope column",
+    )
+    parser.add_argument(
+        '--start_date',
+        type=str,
+        default=None,
+        help="Find >= dates in date_time column",
+    )
+    parser.add_argument(
+        '--end_date',
+        type=str,
+        default=None,
+        help="Find <= dates in date_time column",
+    )
+    parser.add_argument(
+        '--description',
+        type=str,
+        default=None,
+        help="Find substring in description column",
     )
     return parser.parse_args()
 
 
 def query_data(login,
-               search_dict=None,
-               ):
+               project_id=None,
+               microscope=None,
+               start_date=None,
+               end_date=None,
+               description=None):
     """
     Provide CLI access to wrappers for common queries.
+    Prints the dataset IDs of the datasets returned from the query to the
+    standard output device.
 
     :param str login: Full path to json file containing database login
             credentials
-    :param dict search_dict: Key/value pairs for dataset fields that should
-            be queried over
+    :param str project_id: First part of dataset_serial containing
+            project ID (e.g. ML)
+    :param str microscope: Microscope column
+    :param str start_date: Find >= dates in date_time column
+    :param str end_date: Find <= dates in date_time column
+    :param str description: Find substring in description column
     """
     # Get database connection URI
     db_connection = db_utils.get_connection_str(login)
 
+    search_dict = {}
+    if project_id is not None:
+        search_dict['project_id'] = project_id
+    if microscope is not None:
+        search_dict['microscope'] = microscope
+    if start_date is not None:
+        search_dict['start_date'] = start_date
+    if end_date is not None:
+        search_dict['end_date'] = end_date
+    if description is not None:
+        search_dict['description'] = description
+
     with db_ops.session_scope(db_connection) as session:
         datasets = db_ops.get_datasets(session, search_dict)
-        for d in datasets:
-            print(d.dataset_serial)
+        print("Number of datasets matching your query: {}".format(len(datasets)))
+        for i, d in enumerate(datasets):
+            print(i, d.dataset_serial)
 
 
 if __name__ == '__main__':
     args = parse_args()
     query_data(
         login=args.login,
-        search_dict=args.search_str,
+        project_id=args.project_id,
+        microscope=args.microscope,
+        start_date=args.start_date,
+        end_date=args.end_date,
+        description=args.description,
     )

--- a/imaging_db/database/db_operations.py
+++ b/imaging_db/database/db_operations.py
@@ -56,20 +56,37 @@ def get_datasets(session, search_dict=None):
     query database and return datasets that match the criteria.
 
     :param session: SQLAlchemy session
-    :param dict search_dict: Dictionary with query criteria
-    :return DataSet datasets: dataset IDs that match the query
+    :param dict search_dict: Dictionary with query criteria. Currently available
+        search keys are:
+        project_id: First part of dataset_serial containing project ID (e.g. ML)
+        microscope: Microscope column
+        start_date: Find >= dates in date_time column
+        end_date: Find <= dates in date_time column
+        description: Find substring in description column
+    :return list datasets: DataSets that match the query
     """
     datasets = session.query(DataSet) \
-        .join(FramesGlobal) \
-        .join(Frames) \
         .order_by(DataSet.dataset_serial)
     if 'project_id' in search_dict:
-        assert isinstance(search_dict['project_id'], str),\
-            "Project ID should be str not {}".format(search_dict['project_id'])
         datasets = datasets.filter(
             DataSet.dataset_serial.contains(search_dict['project_id']),
         )
-
+    if 'microscope' in search_dict:
+        datasets = datasets.filter(
+            DataSet.microscope.contains(search_dict['microscope']),
+        )
+    if 'start_date' in search_dict:
+        datasets = datasets.filter(
+            DataSet.date_time >= search_dict['start_date'],
+        )
+    if 'end_date' in search_dict:
+        datasets = datasets.filter(
+            DataSet.date_time <= search_dict['end_date'],
+        )
+    if 'description' in search_dict:
+        datasets = datasets.filter(
+            DataSet.description.contains(search_dict['description']),
+        )
     return datasets.all()
 
 

--- a/imaging_db/database/db_operations.py
+++ b/imaging_db/database/db_operations.py
@@ -332,10 +332,10 @@ class DatabaseOperations:
 
     @staticmethod
     def _slice_frames(frames,
-                      positions='all',
-                      times='all',
-                      channels='all',
-                      slices='all'):
+                      positions=None,
+                      times=None,
+                      channels=None,
+                      slices=None):
         """
         Get specific slices of a set of Frames
 
@@ -353,7 +353,6 @@ class DatabaseOperations:
         :raises ValueError: If an illegal type is given
         :raises AssertionError: If both channels and channel_ids are specified.
         """
-
         sliced_frames = frames
 
         # Filter by channel

--- a/imaging_db/utils/cli_utils.py
+++ b/imaging_db/utils/cli_utils.py
@@ -1,3 +1,6 @@
+import datetime
+
+
 def validate_id(id_str):
     """
     Assert that the ID follows the naming convention
@@ -36,3 +39,30 @@ def validate_id(id_str):
         "Serial number should be 4 digits, {}".format(substrs[7])
     assert 0 <= int(substrs[7]) <= 9999,\
         "Serial number should be 4 integers {}".format(substrs[7])
+
+
+def validate_date(date_str):
+    """
+    Make sure string is a valid date.
+
+    :param str date_str: Date in the format YYYY-MM-DD
+    :raises ValueError: If string is not a valid date
+    """
+    try:
+        return datetime.datetime.strptime(date_str, '%Y-%m-%d')
+    except ValueError:
+        raise ValueError("Incorrect data format, should be YYYY-MM-DD")
+
+
+def assert_date_order(start_date, end_date):
+    """
+    Asserts that end date comes after start date.
+
+    :param str start_date: Start date in the format YYYY-MM-DD
+    :param str end_date: End date in the format YYYY-MM-DD
+    :return bool: True if end date is after start date
+    """
+    start_datetime = validate_date(start_date)
+    end_datetime = validate_date(end_date)
+    assert end_datetime > start_datetime,\
+        "End date {} must come after start date {}".format(end_date, start_date)

--- a/imaging_db/utils/db_utils.py
+++ b/imaging_db/utils/db_utils.py
@@ -1,3 +1,4 @@
+import imaging_db.database.db_operations as db_ops
 import imaging_db.metadata.json_operations as json_ops
 
 
@@ -35,3 +36,17 @@ def get_connection_str(credentials_filename):
         schema_name="CREDENTIALS_SCHEMA")
     # Convert json to string compatible with engine
     return json_to_uri(credentials_json)
+
+
+def check_connection(db_connection):
+    """
+    Make sure you can connect to database before anything else.
+
+    :param str db_connection: URI for connecting to the DB
+    :raises IOError: If you can't connect to the DB
+    """
+    try:
+        with db_ops.session_scope(db_connection) as session:
+            db_ops.test_connection(session)
+    except Exception as e:
+        raise IOError("Can't connect to DB: {}".format(e))

--- a/notebooks/database_queries.ipynb
+++ b/notebooks/database_queries.ipynb
@@ -82,7 +82,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The main table \"Project\" contains the unique identifier, a description, and it's also telling us if the file as been slices or uploaded \"as is\"."
+    "The main table \"Project\" contains the unique identifier, a description, and it's also telling us if the file as been sliced into individual 2D frames or uploaded \"as is\" (uninspected)."
    ]
   },
   {
@@ -1922,7 +1922,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/jsonb_queries.ipynb
+++ b/notebooks/jsonb_queries.ipynb
@@ -4294,7 +4294,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/tests/cli/data_downloader_tests.py
+++ b/tests/cli/data_downloader_tests.py
@@ -150,7 +150,7 @@ class TestDataDownloader(db_basetest.DBBaseTest):
         dest_dir = os.path.join(self.temp_path, 'dest_dir')
         # Download data
         data_downloader.download_data(
-            id=self.dataset_serial,
+            dataset_serial=self.dataset_serial,
             login=self.credentials_path,
             dest=dest_dir,
         )
@@ -210,7 +210,7 @@ class TestDataDownloader(db_basetest.DBBaseTest):
         dest_dir = os.path.join(self.temp_path, 'dest_dir')
         # Download data
         data_downloader.download_data(
-            id=self.dataset_serial,
+            dataset_serial=self.dataset_serial,
             login=self.credentials_path,
             dest=dest_dir,
             channels='1',
@@ -232,7 +232,7 @@ class TestDataDownloader(db_basetest.DBBaseTest):
         dest_dir = os.path.join(self.temp_path, 'dest_dir')
         # Download data
         data_downloader.download_data(
-            id=self.dataset_serial,
+            dataset_serial=self.dataset_serial,
             login=self.credentials_path,
             dest=dest_dir,
             positions='0',
@@ -258,7 +258,7 @@ class TestDataDownloader(db_basetest.DBBaseTest):
         dest_dir = os.path.join(self.temp_path, 'dest_dir')
         # Download data
         data_downloader.download_data(
-            id=self.dataset_serial_file,
+            dataset_serial=self.dataset_serial_file,
             login=self.credentials_path,
             dest=dest_dir,
             metadata=False,
@@ -284,7 +284,7 @@ class TestDataDownloader(db_basetest.DBBaseTest):
         )
         dest_dir = os.path.join(self.temp_path, 'dest_dir')
         data_downloader.download_data(
-            id=self.dataset_serial_file,
+            dataset_serial=self.dataset_serial_file,
             login=self.credentials_path,
             dest=dest_dir,
             nbr_workers=2,
@@ -299,7 +299,7 @@ class TestDataDownloader(db_basetest.DBBaseTest):
         self.tempdir.makedir('dest_dir')
         dest_dir = os.path.join(self.temp_path, 'dest_dir')
         data_downloader.download_data(
-            id=self.dataset_serial_file,
+            dataset_serial=self.dataset_serial_file,
             login=self.credentials_path,
             dest=dest_dir,
             metadata=False,
@@ -318,7 +318,7 @@ class TestDataDownloader(db_basetest.DBBaseTest):
         )
         dest_dir = os.path.join(self.temp_path, 'dest_dir')
         data_downloader.download_data(
-            id='Not-a-serial',
+            dataset_serial='Not-a-serial',
             login=self.credentials_path,
             dest=dest_dir,
             metadata=False,
@@ -333,7 +333,7 @@ class TestDataDownloader(db_basetest.DBBaseTest):
         self.tempdir.makedir('dest_dir')
         dest_dir = os.path.join(self.temp_path, 'dest_dir')
         data_downloader.download_data(
-            id=self.dataset_serial_file,
+            dataset_serial=self.dataset_serial_file,
             login=self.credentials_path,
             dest=dest_dir,
             metadata=False,

--- a/tests/cli/data_downloader_tests.py
+++ b/tests/cli/data_downloader_tests.py
@@ -142,6 +142,21 @@ class TestDataDownloader(db_basetest.DBBaseTest):
             self.assertEqual(parsed_args.login, 'test_login.json')
             self.assertEqual(parsed_args.nbr_workers, 5)
 
+    def test_parse_args_defaults(self):
+        with patch('argparse._sys.argv',
+                   ['python',
+                    '--id', self.dataset_serial,
+                    '--dest', 'dest_path',
+                    '--login', 'test_login.json']):
+            parsed_args = data_downloader.parse_args()
+            self.assertIsNone(parsed_args.positions)
+            self.assertIsNone(parsed_args.times)
+            self.assertIsNone(parsed_args.channels)
+            self.assertIsNone(parsed_args.slices)
+            self.assertTrue(parsed_args.metadata)
+            self.assertTrue(parsed_args.download)
+            self.assertIsNone(parsed_args.nbr_workers)
+
     @patch('imaging_db.database.db_operations.session_scope')
     def test_download_frames(self, mock_session):
         mock_session.return_value.__enter__.return_value = self.session

--- a/tests/cli/data_downloader_tests.py
+++ b/tests/cli/data_downloader_tests.py
@@ -1,4 +1,3 @@
-import argparse
 import boto3
 import cv2
 import glob
@@ -85,14 +84,11 @@ class TestDataDownloader(db_basetest.DBBaseTest):
             'config_tif_id.json',
         )
         # Upload frames
-        args = argparse.Namespace(
+        data_uploader.upload_data_and_update_db(
             csv=self.csv_path_frames,
             login=self.credentials_path,
             config=self.config_path,
-            nbr_workers=None,
-            override=False,
         )
-        data_uploader.upload_data_and_update_db(args)
         # Upload file
         self.dataset_serial_file = 'FILE-2005-06-09-20-00-00-1000'
         self.file_s3_dir = "raw_files/FILE-2005-06-09-20-00-00-1000"
@@ -109,14 +105,11 @@ class TestDataDownloader(db_basetest.DBBaseTest):
             '..',
             'config_file.json',
         )
-        args = argparse.Namespace(
+        data_uploader.upload_data_and_update_db(
             csv=self.csv_path_file,
             login=self.credentials_path,
             config=config_path,
-            nbr_workers=None,
-            override=False,
         )
-        data_uploader.upload_data_and_update_db(args)
 
     def tearDown(self):
         """

--- a/tests/cli/data_downloader_tests.py
+++ b/tests/cli/data_downloader_tests.py
@@ -155,19 +155,12 @@ class TestDataDownloader(db_basetest.DBBaseTest):
         # Create dest dir
         self.tempdir.makedir('dest_dir')
         dest_dir = os.path.join(self.temp_path, 'dest_dir')
-        args = argparse.Namespace(
+        # Download data
+        data_downloader.download_data(
             id=self.dataset_serial,
             login=self.credentials_path,
             dest=dest_dir,
-            nbr_workers=None,
-            metadata=True,
-            download=True,
-            positions=None,
-            channels=None,
-            times=None,
-            slices=None,
         )
-        data_downloader.download_data(args)
         # Images are separated by slice first then channel
         im_order = [0, 2, 4, 1, 3, 5]
         it = itertools.product(range(self.nbr_channels), range(self.nbr_slices))
@@ -222,19 +215,13 @@ class TestDataDownloader(db_basetest.DBBaseTest):
         # Create dest dir
         self.tempdir.makedir('dest_dir')
         dest_dir = os.path.join(self.temp_path, 'dest_dir')
-        args = argparse.Namespace(
+        # Download data
+        data_downloader.download_data(
             id=self.dataset_serial,
             login=self.credentials_path,
             dest=dest_dir,
-            nbr_workers=None,
-            metadata=True,
-            download=True,
-            positions=None,
             channels='1',
-            times=None,
-            slices=None,
         )
-        data_downloader.download_data(args)
         meta_path = os.path.join(
             dest_dir,
             self.dataset_serial,
@@ -250,19 +237,15 @@ class TestDataDownloader(db_basetest.DBBaseTest):
         # Create dest dir
         self.tempdir.makedir('dest_dir')
         dest_dir = os.path.join(self.temp_path, 'dest_dir')
-        args = argparse.Namespace(
+        # Download data
+        data_downloader.download_data(
             id=self.dataset_serial,
             login=self.credentials_path,
             dest=dest_dir,
-            nbr_workers=None,
-            metadata=True,
-            download=True,
             positions='0',
-            channels=None,
             times='0',
             slices='1',
         )
-        data_downloader.download_data(args)
         meta_path = os.path.join(
             dest_dir,
             self.dataset_serial,
@@ -280,19 +263,14 @@ class TestDataDownloader(db_basetest.DBBaseTest):
         # Create dest dir
         self.tempdir.makedir('dest_dir')
         dest_dir = os.path.join(self.temp_path, 'dest_dir')
-        args = argparse.Namespace(
+        # Download data
+        data_downloader.download_data(
             id=self.dataset_serial_file,
             login=self.credentials_path,
             dest=dest_dir,
-            nbr_workers=2,
             metadata=False,
-            download=True,
-            positions=None,
-            channels=None,
-            times=None,
-            slices=None,
+            nbr_workers=2,
         )
-        data_downloader.download_data(args)
         # See if file has been downloaded
         file_path = os.path.join(
             dest_dir,
@@ -312,19 +290,13 @@ class TestDataDownloader(db_basetest.DBBaseTest):
             os.path.join('dest_dir', self.dataset_serial_file),
         )
         dest_dir = os.path.join(self.temp_path, 'dest_dir')
-        args = argparse.Namespace(
+        data_downloader.download_data(
             id=self.dataset_serial_file,
             login=self.credentials_path,
             dest=dest_dir,
             nbr_workers=2,
             metadata=False,
-            download=True,
-            positions=None,
-            channels=None,
-            times=None,
-            slices=None,
         )
-        data_downloader.download_data(args)
 
     @nose.tools.raises(AssertionError)
     @patch('imaging_db.database.db_operations.session_scope')
@@ -333,19 +305,14 @@ class TestDataDownloader(db_basetest.DBBaseTest):
         # Create dest dir
         self.tempdir.makedir('dest_dir')
         dest_dir = os.path.join(self.temp_path, 'dest_dir')
-        args = argparse.Namespace(
+        data_downloader.download_data(
             id=self.dataset_serial_file,
             login=self.credentials_path,
             dest=dest_dir,
-            nbr_workers=2,
             metadata=False,
             download=False,
-            positions=None,
-            channels=None,
-            times=None,
-            slices=None,
+            nbr_workers=2,
         )
-        data_downloader.download_data(args)
 
     @nose.tools.raises(AssertionError)
     @patch('imaging_db.database.db_operations.session_scope')
@@ -357,19 +324,13 @@ class TestDataDownloader(db_basetest.DBBaseTest):
             os.path.join('dest_dir', self.dataset_serial_file),
         )
         dest_dir = os.path.join(self.temp_path, 'dest_dir')
-        args = argparse.Namespace(
+        data_downloader.download_data(
             id='Not-a-serial',
             login=self.credentials_path,
             dest=dest_dir,
-            nbr_workers=2,
             metadata=False,
-            download=True,
-            positions=None,
-            channels=None,
-            times=None,
-            slices=None,
+            nbr_workers=2,
         )
-        data_downloader.download_data(args)
 
     @nose.tools.raises(AssertionError)
     @patch('imaging_db.database.db_operations.session_scope')
@@ -378,16 +339,11 @@ class TestDataDownloader(db_basetest.DBBaseTest):
         # Create dest dir
         self.tempdir.makedir('dest_dir')
         dest_dir = os.path.join(self.temp_path, 'dest_dir')
-        args = argparse.Namespace(
+        data_downloader.download_data(
             id=self.dataset_serial_file,
             login=self.credentials_path,
             dest=dest_dir,
-            nbr_workers=-2,
             metadata=False,
             download=False,
-            positions=None,
-            channels=None,
-            times=None,
-            slices=None,
+            nbr_workers=-2,
         )
-        data_downloader.download_data(args)

--- a/tests/cli/data_uploader_tests.py
+++ b/tests/cli/data_uploader_tests.py
@@ -1,4 +1,3 @@
-import argparse
 import boto3
 import itertools
 import json
@@ -111,14 +110,11 @@ class TestDataUploader(db_basetest.DBBaseTest):
     @patch('imaging_db.database.db_operations.session_scope')
     def test_upload_frames(self, mock_session):
         mock_session.return_value.__enter__.return_value = self.session
-        args = argparse.Namespace(
+        data_uploader.upload_data_and_update_db(
             csv=self.csv_path,
             login=self.credentials_path,
             config=self.config_path,
-            nbr_workers=None,
-            override=False,
         )
-        data_uploader.upload_data_and_update_db(args)
         # Query database to find data_set and frames
         datasets = self.session.query(db_ops.DataSet) \
             .filter(db_ops.DataSet.dataset_serial == self.dataset_serial)
@@ -225,29 +221,28 @@ class TestDataUploader(db_basetest.DBBaseTest):
         )
         invalid_csv_path = os.path.join(self.temp_path, "invalid_upload.csv")
         upload_csv.to_csv(invalid_csv_path)
-
-        args = argparse.Namespace(
+        data_uploader.upload_data_and_update_db(
             csv=invalid_csv_path,
             login=self.credentials_path,
             config=self.config_path,
-            nbr_workers=None,
-            override=False,
         )
-        data_uploader.upload_data_and_update_db(args)
 
     @patch('imaging_db.database.db_operations.session_scope')
     def test_upload_frames_already_in_db(self, mock_session):
         mock_session.return_value.__enter__.return_value = self.session
-        args = argparse.Namespace(
+        data_uploader.upload_data_and_update_db(
             csv=self.csv_path,
             login=self.credentials_path,
             config=self.config_path,
-            nbr_workers=None,
             override=True,
         )
-        data_uploader.upload_data_and_update_db(args)
         # Try uploading a second time
-        data_uploader.upload_data_and_update_db(args)
+        data_uploader.upload_data_and_update_db(
+            csv=self.csv_path,
+            login=self.credentials_path,
+            config=self.config_path,
+            override=True,
+        )
 
     @patch('imaging_db.database.db_operations.session_scope')
     def test_upload_file(self, mock_session):
@@ -260,14 +255,11 @@ class TestDataUploader(db_basetest.DBBaseTest):
             '..',
             'config_file.json',
         )
-        args = argparse.Namespace(
+        data_uploader.upload_data_and_update_db(
             csv=self.csv_path,
             login=self.credentials_path,
             config=config_path,
-            nbr_workers=None,
-            override=False,
         )
-        data_uploader.upload_data_and_update_db(args)
         # Query database to find data_set and file_global
         datasets = self.session.query(db_ops.DataSet) \
             .filter(db_ops.DataSet.dataset_serial == self.dataset_serial)
@@ -316,46 +308,42 @@ class TestDataUploader(db_basetest.DBBaseTest):
             '..',
             'config_file.json',
         )
-        args = argparse.Namespace(
+        data_uploader.upload_data_and_update_db(
             csv=self.csv_path,
             login=self.credentials_path,
             config=config_path,
-            nbr_workers=None,
             override=True,
         )
-        data_uploader.upload_data_and_update_db(args)
         # Try uploading a second time
-        data_uploader.upload_data_and_update_db(args)
+        data_uploader.upload_data_and_update_db(
+            csv=self.csv_path,
+            login=self.credentials_path,
+            config=config_path,
+            override=True,
+        )
 
     @nose.tools.raises(AssertionError)
     @patch('imaging_db.database.db_operations.session_scope')
     def test_no_csv(self, mock_session):
         # Upload the same file but as file instead of frames
         mock_session.return_value.__enter__.return_value = self.session
-
-        args = argparse.Namespace(
+        data_uploader.upload_data_and_update_db(
             csv='no-csv-path',
             login=self.credentials_path,
             config=self.config_path,
-            nbr_workers=None,
-            override=False,
         )
-        data_uploader.upload_data_and_update_db(args)
 
     @nose.tools.raises(AssertionError)
     @patch('imaging_db.database.db_operations.session_scope')
     def test_negative_workers(self, mock_session):
         # Upload the same file but as file instead of frames
         mock_session.return_value.__enter__.return_value = self.session
-
-        args = argparse.Namespace(
+        data_uploader.upload_data_and_update_db(
             csv=self.csv_path,
             login=self.credentials_path,
             config=self.config_path,
             nbr_workers=-1,
-            override=False,
         )
-        data_uploader.upload_data_and_update_db(args)
 
     @patch('imaging_db.database.db_operations.session_scope')
     def test_upload_ometif(self, mock_session):
@@ -415,11 +403,8 @@ class TestDataUploader(db_basetest.DBBaseTest):
             'config_ome_tiff.json',
         )
         # Upload data
-        args = argparse.Namespace(
+        data_uploader.upload_data_and_update_db(
             csv=csv_path,
             login=self.credentials_path,
             config=config_path,
-            nbr_workers=None,
-            override=False,
         )
-        data_uploader.upload_data_and_update_db(args)

--- a/tests/cli/query_data_tests.py
+++ b/tests/cli/query_data_tests.py
@@ -1,0 +1,162 @@
+from contextlib import contextmanager
+import os
+import sys
+from io import StringIO
+from unittest.mock import patch
+
+import imaging_db.database.db_operations as db_ops
+import imaging_db.cli.query_data as query_data
+import tests.database.db_basetest as db_basetest
+
+
+@contextmanager
+def captured_output():
+    """
+    Context manager that captures stdout and potential errors.
+    https://stackoverflow.com/questions/4219717/
+    how-to-assert-output-with-nosetest-unittest-in-python
+
+    :return str sys.stdout: Console output
+    :return str sys.stderr: Errors
+    """
+    new_out, new_err = StringIO(), StringIO()
+    old_out, old_err = sys.stdout, sys.stderr
+    try:
+        sys.stdout, sys.stderr = new_out, new_err
+        yield sys.stdout, sys.stderr
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err
+
+
+class TestQueryData(db_basetest.DBBaseTest):
+    """
+    Test the data query tool
+    """
+    def setUp(self):
+        super().setUp()
+        # Database credentials file
+        self.credentials_path = os.path.join(
+            os.path.dirname(__file__),
+            '..',
+            '..',
+            'db_credentials.json',
+        )
+        # Add some datasets to session
+        self.dataset_ids = [
+            'PROJECT-2010-04-01-00-00-00-0001',
+            'PROJECT-2010-05-01-00-00-00-0001',
+            'PROJECT-2010-06-01-00-00-00-0001',
+            'MEOW-2010-05-05-00-00-00-0001',
+            'MEOW-2010-06-05-00-00-00-0001',
+        ]
+        self.descriptions = [
+            'First dataset',
+            'Second dataset',
+            'Third dataset',
+            'Very specific description',
+            'Not informative description',
+        ]
+        self.microscopes = [
+            'scope1',
+            'scope2',
+            'scope2',
+            'scope2',
+            'other microscope',
+        ]
+        for i in range(len(self.dataset_ids)):
+            new_dataset = db_ops.DataSet(
+                dataset_serial=self.dataset_ids[i],
+                description=self.descriptions[i],
+                frames=True,
+                microscope=self.microscopes[i],
+                parent_id=None,
+            )
+            self.session.add(new_dataset)
+
+    def tearDown(self):
+        """
+        Rollback database session.
+        """
+        super().tearDown()
+
+    def test_parse_args(self):
+        with patch('argparse._sys.argv',
+                   ['python',
+                    '--login', 'test_login.json',
+                    '--project_id', 'TEST',
+                    '--microscope', 'scope 1',
+                    '--start_date', '2010-05-01',
+                    '--description', 'This is a test']):
+            parsed_args = query_data.parse_args()
+            self.assertEqual(parsed_args.login, 'test_login.json')
+            self.assertEqual(parsed_args.project_id, 'TEST')
+            self.assertEqual(parsed_args.microscope, 'scope 1')
+            self.assertEqual(parsed_args.start_date, '2010-05-01')
+            self.assertIsNone(parsed_args.end_date)
+            self.assertEqual(parsed_args.description, 'This is a test')
+
+    @patch('imaging_db.database.db_operations.session_scope')
+    def test_query_data(self, mock_session):
+        mock_session.return_value.__enter__.return_value = self.session
+        with captured_output() as (out, err):
+            query_data.query_data(
+                login=self.credentials_path,
+                project_id='MEOW',
+            )
+        std_output = out.getvalue().strip()
+        self.assertEqual(
+            std_output,
+            "Number of datasets matching your query: 2\n" +
+            "0 MEOW-2010-05-05-00-00-00-0001\n" +
+            "1 MEOW-2010-06-05-00-00-00-0001",
+        )
+
+    @patch('imaging_db.database.db_operations.session_scope')
+    def test_query_data_dates(self, mock_session):
+        mock_session.return_value.__enter__.return_value = self.session
+        with captured_output() as (out, err):
+            query_data.query_data(
+                login=self.credentials_path,
+                start_date='2010-05-01',
+                end_date='2010-06-15',
+            )
+        std_output = out.getvalue().strip()
+        self.assertEqual(
+            std_output,
+            "Number of datasets matching your query: 4\n" +
+            "0 MEOW-2010-05-05-00-00-00-0001\n" +
+            "1 MEOW-2010-06-05-00-00-00-0001\n" +
+            "2 PROJECT-2010-05-01-00-00-00-0001\n" +
+            "3 PROJECT-2010-06-01-00-00-00-0001",
+        )
+
+    @patch('imaging_db.database.db_operations.session_scope')
+    def test_query_data_scope_project(self, mock_session):
+        mock_session.return_value.__enter__.return_value = self.session
+        with captured_output() as (out, err):
+            query_data.query_data(
+                login=self.credentials_path,
+                project_id='MEOW',
+                microscope='scope2',
+            )
+        std_output = out.getvalue().strip()
+        self.assertEqual(
+            std_output,
+            "Number of datasets matching your query: 1\n" +
+            "0 MEOW-2010-05-05-00-00-00-0001",
+        )
+
+    @patch('imaging_db.database.db_operations.session_scope')
+    def test_query_data_description(self, mock_session):
+        mock_session.return_value.__enter__.return_value = self.session
+        with captured_output() as (out, err):
+            query_data.query_data(
+                login=self.credentials_path,
+                description='Second',
+            )
+        std_output = out.getvalue().strip()
+        self.assertEqual(
+            std_output,
+            "Number of datasets matching your query: 1\n" +
+            "0 PROJECT-2010-05-01-00-00-00-0001",
+        )

--- a/tests/cli/query_data_tests.py
+++ b/tests/cli/query_data_tests.py
@@ -148,6 +148,21 @@ class TestQueryData(db_basetest.DBBaseTest):
         )
 
     @patch('imaging_db.database.db_operations.session_scope')
+    def test_query_data_scope_no_return_datasets(self, mock_session):
+        mock_session.return_value.__enter__.return_value = self.session
+        with captured_output() as (out, err):
+            query_data.query_data(
+                login=self.credentials_path,
+                project_id='MEOW',
+                microscope='scope1',
+            )
+        std_output = out.getvalue().strip()
+        self.assertEqual(
+            std_output,
+            "Number of datasets matching your query: 0"
+        )
+
+    @patch('imaging_db.database.db_operations.session_scope')
     def test_query_data_description(self, mock_session):
         mock_session.return_value.__enter__.return_value = self.session
         with captured_output() as (out, err):
@@ -170,4 +185,12 @@ class TestQueryData(db_basetest.DBBaseTest):
             login=self.credentials_path,
             start_date='2010-06-01',
             end_date='2010-05-01',
+        )
+
+    @nose.tools.raises(TypeError)
+    @patch('imaging_db.database.db_operations.session_scope')
+    def test_query_data_no_loging(self, mock_session):
+        mock_session.return_value.__enter__.return_value = self.session
+        query_data.query_data(
+            start_date='2010-05-01',
         )

--- a/tests/cli/query_data_tests.py
+++ b/tests/cli/query_data_tests.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+import nose.tools
 import os
 import sys
 from io import StringIO
@@ -159,4 +160,14 @@ class TestQueryData(db_basetest.DBBaseTest):
             std_output,
             "Number of datasets matching your query: 1\n" +
             "0 PROJECT-2010-05-01-00-00-00-0001",
+        )
+
+    @nose.tools.raises(AssertionError)
+    @patch('imaging_db.database.db_operations.session_scope')
+    def test_query_data_description(self, mock_session):
+        mock_session.return_value.__enter__.return_value = self.session
+        query_data.query_data(
+            login=self.credentials_path,
+            start_date='2010-06-01',
+            end_date='2010-05-01',
         )

--- a/tests/database/db_operations_tests.py
+++ b/tests/database/db_operations_tests.py
@@ -68,6 +68,14 @@ class TestDBOperations(db_basetest.DBBaseTest):
             .filter(db_ops.DataSet.dataset_serial == self.dataset_serial) \
             .order_by(db_ops.Frames.file_name)
 
+        # Add some more datasets for queries
+        self.dataset_ids = [
+            'PROJECT-2010-04-01-00-00-00-0001',
+            'PROJECT-2010-05-01-00-00-00-0001',
+            'PROJECT-2010-06-01-00-00-00-0001']
+        self.descriptions = ['First dataset', 'Second dataset', 'Third dataset']
+        self.microscopes = ['scope1', 'scope2', 'scope2']
+
     def tearDown(self):
         super().tearDown()
 
@@ -77,6 +85,32 @@ class TestDBOperations(db_basetest.DBBaseTest):
     @nose.tools.raises(ConnectionError)
     def test_connection_no_session(self):
         db_ops.test_connection('session')
+
+    def test_get_datasets(self):
+        search_dict = {'project_id': 'TEST'}
+        datasets = db_ops.get_datasets(self.session, search_dict)
+        self.assertEqual(len(datasets), 1)
+        self.assertEqual(datasets[0].dataset_serial, self.dataset_serial)
+
+    # def test_get_datasets_project(self):
+    #     # Add a few more datasets
+    #     # TODO: Need to add this in db_operations for query to work
+    #     for i in range(len(self.dataset_ids)):
+    #         new_dataset = db_ops.DataSet(
+    #             dataset_serial=self.dataset_ids[i],
+    #             description=self.descriptions[i],
+    #             frames=True,
+    #             microscope=self.microscopes[i],
+    #             parent_id=None,
+    #         )
+    #         self.session.add(new_dataset)
+    #
+    #     search_dict = {'project_id': 'PROJECT'}
+    #     datasets = db_ops.get_datasets(self.session, search_dict)
+    #     self.assertEqual(len(datasets), 3)
+    #     for i, d in enumerate(datasets):
+    #         print(i, d.dataset_serial)
+    #         self.assertEqual(d.dataset_serial, self.dataset_ids[i])
 
     @nose.tools.raises(AssertionError)
     def test_assert_unique_id(self):
@@ -188,8 +222,6 @@ class TestDBOperations(db_basetest.DBBaseTest):
             .filter(db_ops.DataSet.dataset_serial == dataset_serial)
         self.assertEqual(datasets.count(), 1)
         dataset = datasets[0]
-        # This is the second dataset inserted
-        self.assertEqual(dataset.id, 2)
         self.assertEqual(dataset.dataset_serial, dataset_serial)
         date_time = dataset.date_time
         self.assertEqual(date_time.year, 2005)

--- a/tests/database/db_operations_tests.py
+++ b/tests/database/db_operations_tests.py
@@ -281,7 +281,7 @@ class TestDBOperations(db_basetest.DBBaseTest):
     def test_slice_frames_select(self):
         sliced_frames = self.db_inst._slice_frames(
             frames=self.frames,
-            pos=(50,),
+            positions=(50,),
             times=(5,),
             channels=(1, 2),
             slices=(1,),
@@ -308,7 +308,7 @@ class TestDBOperations(db_basetest.DBBaseTest):
     def test_slice_frames_invalid_channel_tuple(self):
         self.db_inst._slice_frames(
             frames=self.frames,
-            pos=(50,),
+            positions=(50,),
             times=(5,),
             channels=(1, '2'),
             slices=(1,),
@@ -325,7 +325,7 @@ class TestDBOperations(db_basetest.DBBaseTest):
     def test_slice_frames_invalid_pos(self):
         self.db_inst._slice_frames(
             frames=self.frames,
-            pos=3,
+            positions=3,
         )
 
     def test_get_meta_from_frames(self):

--- a/tests/utils/cli_utils_tests.py
+++ b/tests/utils/cli_utils_tests.py
@@ -36,3 +36,29 @@ def test_invalid_serial():
 def test_underscore():
     id_str = "ISP_666-12-08-15-45-00-0001"
     cli_utils.validate_id(id_str)
+
+
+def test_validate_date():
+    date = cli_utils.validate_date('2019-05-07')
+    nose.tools.assert_equal(date.year, 2019)
+    nose.tools.assert_equal(date.month, 5)
+    nose.tools.assert_equal(date.day, 7)
+
+
+@nose.tools.raises(ValueError)
+def test_validate_date_nosuchdate():
+    cli_utils.validate_date('2019-55-77')
+
+
+@nose.tools.raises(ValueError)
+def test_validate_date_wrong_format():
+    cli_utils.validate_date('19-01-01')
+
+
+def test_assert_date_order():
+    cli_utils.assert_date_order('2018-05-17', '2018-06-15')
+
+
+@nose.tools.raises(AssertionError)
+def test_assert_date_order_wrong():
+    cli_utils.assert_date_order('2018-06-17', '2018-06-15')

--- a/tests/utils/db_utils_tests.py
+++ b/tests/utils/db_utils_tests.py
@@ -1,7 +1,9 @@
 import nose.tools
 import os
+from unittest.mock import patch
 
 import imaging_db.utils.db_utils as db_utils
+import tests.database.db_basetest as db_basetest
 
 
 def test_json_to_uri():
@@ -30,3 +32,20 @@ def test_get_connection_str():
     credentials_str = db_utils.get_connection_str(credentials_filename)
     expected_str = "postgres://imaging_user:imaging_passwd@localhost:5433/imaging_test"
     nose.tools.assert_equal(credentials_str, expected_str)
+
+
+class TestConnection(db_basetest.DBBaseTest):
+    """
+    Test the data connection
+    """
+    def setUp(self):
+        super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
+
+    @patch('imaging_db.database.db_operations.session_scope')
+    def test_connection(self, mock_session):
+        mock_session.return_value.__enter__.return_value = self.session
+        connection_str = "postgres://imaging_user:imaging_passwd@localhost:5433/imaging_test"
+        db_utils.check_connection(connection_str)

--- a/tests/utils/meta_utils_tests.py
+++ b/tests/utils/meta_utils_tests.py
@@ -48,6 +48,7 @@ def test_validate_global_meta():
     }
     meta_utils.validate_global_meta(global_meta)
 
+
 def test_gen_sha256_numpy():
     expected_sha = 'd1b8118646637256b66ef034778f8d0add8d00436ad1ebb051ef09cf19dbf2d2'
 
@@ -87,6 +88,7 @@ def test_gen_sha256_file():
         sha = meta_utils.gen_sha256(file_path)
     nose.tools.assert_equal(expected_sha, sha)
 
+
 @nose.tools.raises(AssertionError)
 def test_validate_global_meta_invalid():
     global_meta = {
@@ -102,6 +104,7 @@ def test_validate_global_meta_invalid():
         "nbr_positions": 9,
     }
     meta_utils.validate_global_meta(global_meta)
+
 
 @nose.tools.raises(AssertionError)
 def test_validate_global_meta_missing():


### PR DESCRIPTION
Added a CLI query tool for datasets as a quick way to get some IDs for download (just basic functionality which can be expanded on).

Changed input of CLIs from parseargs namespace to regular params so you can easily call the download_data, upload_data and query_data functions outside of the CLIs.

Added a conda environment yaml file for easy setup.

Fixed broken travis CI settings.